### PR TITLE
POST フォームの action に「?uid=NULLGWDOCOMO」を付加した場合の対応

### DIFF
--- a/src/chrome/content/contentHandler/docomo.js
+++ b/src/chrome/content/contentHandler/docomo.js
@@ -78,9 +78,6 @@ firemobilesimulator.contentHandler.docomo = {
     ndDocument.addEventListener("keypress", firemobilesimulator.contentHandler.common.createAccessKeyFunction(["accesskey"]), false);
   
     // formのUTN送信
-    // uid=NULLGWDOCOMOのPOST送信
-    // オープンiエリアの場合のメソッドを強制的にGETに書き換え
-    // ##本当はhttp-on-modify-requestで書き換えたい##
     var formTags = ndDocument.getElementsByTagName("form");
     for (var i = 0; i < formTags.length; i++) {
       var formTag = formTags[i];
@@ -95,29 +92,6 @@ firemobilesimulator.contentHandler.docomo = {
       if (null != lcs) {
         dump("setlcs for form tag\n");
         formTag.addEventListener("submit", setLcsFunction, false);
-      }
-  
-      // オープンiエリアの場合のメソッドを強制的にGETに書き換え
-      var action = formTag.getAttribute("action");
-      if (action && action == "http://w1m.docomo.ne.jp/cp/iarea") {
-        formTag.setAttribute("method", "GET");
-      }
-  
-      // uid=NULLGWDOCOMOのPOST送信
-      var method = formTag.getAttribute("method");
-      if (method && method.toUpperCase() == "POST") {
-        var inputTags = formTag.getElementsByTagName("input");
-        for (var j = 0; j < inputTags.length; j++) {
-          var inputTag = inputTags[j];
-          var key = inputTag.getAttribute("name");
-          var value = inputTag.value;
-          if (key && value && key.toUpperCase() == "UID"
-              && value.toUpperCase() == "NULLGWDOCOMO") {
-            dump("replace uid\n");
-            var uid = firemobilesimulator.common.carrier.getId(firemobilesimulator.common.carrier.idType.DOCOMO_UID,deviceId);
-            inputTag.value = uid;
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
POSTの飛び先にuid=NULLGWDOCOMOをつけると・・・
http://firemobilesimulator.org/?%A4%AA%CC%E4%A4%A4%B9%E7%A4%EF%A4%BB%2F%B2%E1%B5%EE%A5%ED%A5%B01#i242c71e
として報告されている件ですが、実機ではこのような挙動は発生しておらず、
FireMobileSimulator 特有の挙動のようです。（Chrome 版でも発生していません。）

https://github.com/muraoka17/FireMobileSimulator/commit/d473ab290268c421ec0b3ff0ebf399d535126034
でこの問題に対応している方がいましたので、1.2.2 をベースにマージしてみました。
（1.2.3 のコミットが見当たらなかったため、1.2.2 をベースにしています。）

ブランチ構成も処理内容もよくわかっていないので、おかしなことをやっているかもしれません。
必要でしたら、改めてマージしなおしますのでご連絡ください。
